### PR TITLE
Run cram tests on 2.6 only

### DIFF
--- a/build.py
+++ b/build.py
@@ -20,6 +20,8 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
+import sys
+
 from pybuilder.core import use_plugin, init
 
 use_plugin("python.core")
@@ -31,7 +33,8 @@ use_plugin("python.distutils")
 use_plugin("copy_resources")
 use_plugin("python.frosted")
 use_plugin("python.pycharm")
-use_plugin("python.cram")
+if sys.version_info[0:2] == (2, 6):
+    use_plugin("python.cram") # we have a 2.6 shebang in the scripts
 
 
 name = "aws-stager"


### PR DESCRIPTION
We have a 2.6 shebang in the scripts so we have to
ensure that we installed runtime dependencies on 2.6.
Only way to do this reliably is have a sourced 2.6 virtualenv
so that env finds the `python2.6` program.
This means that we can only run cram tests on 2.6
